### PR TITLE
refactor: Make column a plain object

### DIFF
--- a/src/schema/column.ts
+++ b/src/schema/column.ts
@@ -37,7 +37,7 @@ export const formatColumn = (column: Column): string => {
   return `Column(name=${name}, type=${type}, description=${description}, primary_key=${primaryKey}, not_null=${notNull}, incremental_key=${incrementalKey}, unique=${unique})`;
 };
 
-export const equals = (column: Column, other: object): boolean => {
+export const equals = (column: Column, other: unknown): boolean => {
   return isDeepStrictEqual(column, other);
 };
 

--- a/src/transformers/openapi.test.ts
+++ b/src/transformers/openapi.test.ts
@@ -1,7 +1,7 @@
 import { Utf8, Int64, Bool } from '@apache-arrow/esnext-esm';
 import test from 'ava';
 
-import { Column } from '../schema/column.js';
+import { Column, createColumn } from '../schema/column.js';
 import { JSONType } from '../types/json.js';
 
 import { oapiDefinitionToColumns } from './openapi.js';
@@ -49,12 +49,36 @@ const OAPI_SPEC = {
 
 test('should parse spec as expected', (t) => {
   const expectedColumns: Column[] = [
-    new Column('string', new Utf8(), ''),
-    new Column('number', new Int64(), ''),
-    new Column('integer', new Int64(), ''),
-    new Column('boolean', new Bool(), ''),
-    new Column('object', new JSONType(), ''),
-    new Column('array', new JSONType(), ''),
+    createColumn({
+      name: 'string',
+      type: new Utf8(),
+      description: '',
+    }),
+    createColumn({
+      name: 'number',
+      type: new Int64(),
+      description: '',
+    }),
+    createColumn({
+      name: 'integer',
+      type: new Int64(),
+      description: '',
+    }),
+    createColumn({
+      name: 'boolean',
+      type: new Bool(),
+      description: '',
+    }),
+    createColumn({
+      name: 'object',
+      type: new JSONType(),
+      description: '',
+    }),
+    createColumn({
+      name: 'array',
+      type: new JSONType(),
+      description: '',
+    }),
   ];
 
   const columns = oapiDefinitionToColumns(OAPI_SPEC['definitions']['TestDefinition']);

--- a/src/transformers/openapi.ts
+++ b/src/transformers/openapi.ts
@@ -1,6 +1,6 @@
 import { DataType, Utf8, Int64, Bool } from '@apache-arrow/esnext-esm';
 
-import { Column } from '../schema/column.js';
+import { Column, createColumn } from '../schema/column.js';
 import { JSONType } from '../types/json.js';
 
 interface OAPIProperty {
@@ -55,7 +55,7 @@ export function oapiDefinitionToColumns(definition: OAPIDefinition, overrideColu
   for (const key in definition.properties) {
     const value = definition.properties[key];
     const columnType = oapiTypeToArrowType(value);
-    const column = new Column(key, columnType, value.description);
+    const column = createColumn({ name: key, type: columnType, description: value.description });
     const overrideColumn = getColumnByName(overrideColumns, key);
     if (overrideColumn) {
       column.type = overrideColumn.type;


### PR DESCRIPTION
Column doesn't have internal state so we can keep it as a plain object with utility methods