### PR TITLE
fix: Write gRPC call, use `for await` on write readable stream

### DIFF
--- a/src/grpc/plugin.ts
+++ b/src/grpc/plugin.ts
@@ -111,8 +111,16 @@ export class PluginServer extends pluginV3.cloudquery.plugin.v3.UnimplementedPlu
     this.plugin.read(call);
   }
   Write(call: WriteStream, callback: grpc.sendUnaryData<pluginV3.cloudquery.plugin.v3.Write.Response>): void {
-    this.plugin.write(call);
-    callback(null, new pluginV3.cloudquery.plugin.v3.Write.Response());
+    this.plugin
+      .write(call)
+      .then(() => {
+        // eslint-disable-next-line promise/no-callback-in-promise
+        return callback(null, new pluginV3.cloudquery.plugin.v3.Write.Response());
+      })
+      .catch((error) => {
+        // eslint-disable-next-line promise/no-callback-in-promise
+        return callback(error, null);
+      });
   }
   Close(
     call: grpc.ServerUnaryCall<

--- a/src/plugin/plugin.ts
+++ b/src/plugin/plugin.ts
@@ -36,7 +36,7 @@ export interface SourceClient {
 
 export interface DestinationClient {
   read: (stream: ReadStream) => void;
-  write: (stream: WriteStream) => void;
+  write: (stream: WriteStream) => Promise<void>;
 }
 
 export interface Client extends SourceClient, DestinationClient {
@@ -72,7 +72,7 @@ export const newPlugin = (name: string, version: string, newClient: NewClientFun
     name: () => name,
     version: () => version,
     write: (stream: WriteStream) => {
-      return plugin.client?.write(stream) ?? new Error('client not initialized');
+      return plugin.client?.write(stream) ?? Promise.reject(new Error('client not initialized'));
     },
     read: (stream: ReadStream) => {
       return plugin.client?.read(stream) ?? new Error('client not initialized');


### PR DESCRIPTION
For readable streams like the one for the `write` gRPC call we can `for await` instead of listening to stream events