### PR TITLE
fix: Extension types null values

### DIFF
--- a/src/memdb/tables.ts
+++ b/src/memdb/tables.ts
@@ -15,6 +15,7 @@ export const createTables = () => {
       resolver: (clientMeta, parent, stream) => {
         stream.write({ id: 'id-1', json: '{ "a": 1 }' });
         stream.write({ id: 'id-2', json: [1, 2, 3] });
+        stream.write({ id: 'id-3' });
         return Promise.resolve();
       },
       columns: [

--- a/src/scalar/json.ts
+++ b/src/scalar/json.ts
@@ -1,5 +1,7 @@
 import { Utf8 as ArrowString } from '@apache-arrow/esnext-esm';
 
+import { Nullable } from '../schema/types.js';
+
 import { Scalar } from './scalar.js';
 import { isInvalid, NULL_VALUE } from './util.js';
 
@@ -12,9 +14,9 @@ const validate = (value: string) => {
   }
 };
 
-class JSONType implements Scalar<Uint8Array> {
+class JSONType implements Scalar<Nullable<Uint8Array>> {
   private _valid = false;
-  private _value = new TextEncoder().encode(NULL_VALUE);
+  private _value: Nullable<Uint8Array> = null;
 
   public constructor(v?: unknown) {
     this.value = v;
@@ -29,7 +31,7 @@ class JSONType implements Scalar<Uint8Array> {
     return this._valid;
   }
 
-  public get value(): Uint8Array {
+  public get value(): Nullable<Uint8Array> {
     return this._value;
   }
 

--- a/src/scalar/list.ts
+++ b/src/scalar/list.ts
@@ -1,11 +1,11 @@
 import { DataType, List as ArrowList } from '@apache-arrow/esnext-esm';
 
-import { Scalar, Stringable } from './scalar.js';
+import { Scalar } from './scalar.js';
 import { isInvalid, NULL_VALUE } from './util.js';
 
-type TVector<T extends Scalar<Stringable>> = T[];
+type TVector<T extends Scalar<unknown>> = T[];
 
-export class List<T extends Scalar<Stringable>> implements Scalar<TVector<T>> {
+export class List<T extends Scalar<unknown>> implements Scalar<TVector<T>> {
   private _childScalarInstance: T;
   private _valid = false;
   private _value: TVector<T> = [];

--- a/src/scalar/scalar.ts
+++ b/src/scalar/scalar.ts
@@ -19,9 +19,7 @@ import { Uint32 } from './uint32.js';
 import { Uint64 } from './uint64.js';
 import { UUID } from './uuid.js';
 
-export type Stringable = { toString: () => string };
-
-export interface Scalar<T extends Stringable> {
+export interface Scalar<T> {
   toString: () => string;
   get valid(): boolean;
   get value(): T;
@@ -29,9 +27,9 @@ export interface Scalar<T extends Stringable> {
   get dataType(): DataType;
 }
 
-export type Vector = Scalar<Stringable>[];
+export type Vector = Scalar<unknown>[];
 
-export const newScalar = (dataType: DataType): Scalar<Stringable> => {
+export const newScalar = (dataType: DataType): Scalar<unknown> => {
   if (DataType.isBool(dataType)) {
     return new Bool();
   }

--- a/src/scalar/uuid.ts
+++ b/src/scalar/uuid.ts
@@ -1,12 +1,14 @@
 import { FixedSizeBinary } from '@apache-arrow/esnext-esm';
 import { validate } from 'uuid';
 
+import { Nullable } from '../schema/types.js';
+
 import { Scalar } from './scalar.js';
 import { isInvalid, NULL_VALUE } from './util.js';
 
-export class UUID implements Scalar<Uint8Array> {
+export class UUID implements Scalar<Nullable<Uint8Array>> {
   private _valid = false;
-  private _value = new TextEncoder().encode(NULL_VALUE);
+  private _value: Nullable<Uint8Array> = null;
 
   public constructor(v?: unknown) {
     this.value = v;
@@ -20,7 +22,7 @@ export class UUID implements Scalar<Uint8Array> {
     return this._valid;
   }
 
-  public get value(): Uint8Array {
+  public get value(): Nullable<Uint8Array> {
     return this._value;
   }
 

--- a/src/schema/resource.ts
+++ b/src/schema/resource.ts
@@ -1,6 +1,6 @@
 import { tableToIPC, Table as ArrowTable, RecordBatch, vectorFromArray } from '@apache-arrow/esnext-esm';
 
-import { Scalar, Vector, newScalar, Stringable } from '../scalar/scalar.js';
+import { Scalar, Vector, newScalar } from '../scalar/scalar.js';
 import { isExtensionType } from '../types/extensions.js';
 
 import { cqIDColumn } from './meta.js';
@@ -20,7 +20,7 @@ export class Resource {
     this.data = table.columns.map((column) => newScalar(column.type));
   }
 
-  getColumnData(columnName: string): Scalar<Stringable> {
+  getColumnData(columnName: string): Scalar<unknown> {
     const columnIndex = this.table.columns.findIndex((c) => c.name === columnName);
     if (columnIndex === undefined) {
       throw new Error(`Column '${columnName}' not found`);


### PR DESCRIPTION
We should return `null` to designate `null` JSON and UUIDs