### PR TITLE
fix: Add --license placeholder for future use

### DIFF
--- a/src/plugin/serve.ts
+++ b/src/plugin/serve.ts
@@ -164,6 +164,12 @@ export const createServeCommand = (plugin: Plugin) => {
         choices: TELEMETRY_LEVEL_CHOICES,
         default: 'all',
       },
+      // eslint-disable-next-line @typescript-eslint/naming-convention
+      license: {
+        type: 'string',
+        description: 'set offline license file (placeholder for future use)',
+        default: '',
+      },
     })
     .env('CQ_')
     .strict()

--- a/src/plugin/serve.ts
+++ b/src/plugin/serve.ts
@@ -54,6 +54,11 @@ export const createServeCommand = (plugin: Plugin) => {
             description: 'network to bind to',
             default: 'tcp',
           },
+          license: {
+            type: 'string',
+            description: 'set offline license file (placeholder for future use)',
+            default: '',
+          },
         });
       },
       ({ address, logLevel, logFormat }: ServeArguments) => {
@@ -163,12 +168,6 @@ export const createServeCommand = (plugin: Plugin) => {
         hidden: true,
         choices: TELEMETRY_LEVEL_CHOICES,
         default: 'all',
-      },
-      // eslint-disable-next-line @typescript-eslint/naming-convention
-      license: {
-        type: 'string',
-        description: 'set offline license file (placeholder for future use)',
-        default: '',
       },
     })
     .env('CQ_')


### PR DESCRIPTION
plugin-pb-go [1.15.0](https://github.com/cloudquery/plugin-pb-go/pull/196) now uses `--license` when invoking plugins, if one is set by the cli.