### PR TITLE
chore: Move blockExoticSubdeps from .npmrc to pnpm-workspace.yaml

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-block-exotic-subdeps=true

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,1 +1,3 @@
+blockExoticSubdeps: true
+
 minimumReleaseAge: 10080 # 7 days


### PR DESCRIPTION
Move `blockExoticSubdeps` setting to `pnpm-workspace.yaml` per https://pnpm.io/settings#blockexoticsubdeps