### PR TITLE
fix: Unblock dependency updates

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,3 +1,10 @@
 {
   extends: ["github>cloudquery/.github//.github/renovate-node-default.json5"],
+  packageRules: [
+    {
+      // typescript-eslint does not support TS 7 yet: https://github.com/typescript-eslint/typescript-eslint/issues/10940
+      matchPackageNames: ["typescript"],
+      allowedVersions: "<7",
+    },
+  ],
 }

--- a/src/scalar/json.ts
+++ b/src/scalar/json.ts
@@ -72,7 +72,7 @@ class JSONType implements Scalar<Nullable<Uint8Array>> {
   }
 
   public toString() {
-    if (this._valid) {
+    if (this._valid && this._value !== null) {
       return new TextDecoder().decode(this._value);
     }
 

--- a/src/scheduler/scheduler.ts
+++ b/src/scheduler/scheduler.ts
@@ -269,5 +269,4 @@ export const sync = async ({
   }
 
   stream.end();
-  return await Promise.resolve();
 };


### PR DESCRIPTION
Fixes the source-level breakages that block the open Renovate PRs: null-guards the JSON scalar decode for @apache-arrow/esnext-esm 21.2.0, drops the redundant `Promise.resolve` return flagged by eslint-plugin-unicorn 72, and pins typescript below v7 until [typescript-eslint supports it](https://github.com/typescript-eslint/typescript-eslint/issues/10940).